### PR TITLE
Avoid ReferenceError

### DIFF
--- a/src/features.js
+++ b/src/features.js
@@ -32,6 +32,6 @@ export function isSupported() {
     "classList" in document.documentElement &&
     Object.assign &&
     Object.keys &&
-    requestAnimationFrame
+    window.requestAnimationFrame
   );
 }


### PR DESCRIPTION
Avoid ReferenceError when requestAnimationFrame is not exist.